### PR TITLE
Rev the version to v0.0.35 but do not publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nchannel/nav2009fg-channel",
-  "version": "0.0.2",
+  "version": "0.0.35",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nchannel/nav2009fg-channel",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
   "scripts": {
     "test": "mocha --timeout 10000 validation/*.spec.js"
   },
-  "version": "0.0.2"
+  "version": "0.0.35"
 }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
   "scripts": {
     "test": "mocha --timeout 10000 validation/*.spec.js"
   },
-  "version": "0.0.1"
+  "version": "0.0.2"
 }


### PR DESCRIPTION
previously the package.json and the package-lock.json were not properly maintained.  I am setting them to v0.0.35 using the npm client to ensure all is well.  

There are no actual channel changes so I will not publish, rather I will just let it publish v0.0.35 with the "notcertified" tag and stop